### PR TITLE
Resets the app state after an elapsed time from check-in

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ module.exports = function (api) {
   api.cache(true);
 
   return {
-    exclude: ["node_modules/@babel/**"],
+    exclude: process.env.NODE_ENV === "test" ? [] : ["node_modules/@babel/**"],
     plugins: [
       "@babel/plugin-syntax-dynamic-import",
       [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  moduleFileExtensions: ["js", "svelte"],
+  moduleFileExtensions: ["js", "mjs", "svelte"],
+  moduleDirectories: ["node_modules", "src/node_modules"],
   moduleNameMapper: {
     "^\\$(.*)$": "<rootDir>/src/$1",
   },
@@ -11,10 +12,12 @@ module.exports = {
   testPathIgnorePatterns: [
     "<rootDir>/__sapper__/",
     "<rootDir>/node_modules/",
-    "<rootDir>/src/node_modules/",
+    "<rootDir>/src/node_modules/(?!@sapper)",
   ],
   transform: {
-    "^.+\\.js$": ["babel-jest"],
+    "^.+\\.js$": "babel-jest",
+    "^.+\\.mjs$": "babel-jest",
     "^.+\\.svelte$": ["svelte-jester", { preprocess: true }],
   },
+  transformIgnorePatterns: ["src/node_modules/(?!@sapper)"],
 };

--- a/src/components/Form/Button/index.svelte
+++ b/src/components/Form/Button/index.svelte
@@ -1,8 +1,9 @@
 <script>
   export let disabled = false;
+  export let type = "submit";
 </script>
 
-<button type="submit" {disabled}><slot /></button>
+<button {type} {disabled} on:click><slot /></button>
 
 <style lang="scss">
   button {
@@ -12,6 +13,7 @@
     color: var(--white);
     height: var(--form-height);
     justify-self: stretch;
+    padding: 0 1.5ch;
   }
 
   [disabled] {

--- a/src/components/InQueue/InQueue.test.js
+++ b/src/components/InQueue/InQueue.test.js
@@ -1,12 +1,14 @@
 import InQueue from ".";
-import { render } from "@testing-library/svelte";
-import { getCustomerDetails } from "$lib/services/kiosk";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { getCustomerDetails, getData } from "$lib/services/kiosk";
 import getPositionResolver from "$lib/resolvers/getPosition";
 import currentCustomerResolver from "$lib/resolvers/currentCustomer";
+import stateResolver from "$lib/resolvers/state";
 
 jest.mock("$lib/services/kiosk");
 jest.mock("$lib/resolvers/getPosition");
 jest.mock("$lib/resolvers/currentCustomer");
+jest.mock("$lib/resolvers/state");
 
 describe("InQueue", () => {
   const data = {
@@ -16,6 +18,8 @@ describe("InQueue", () => {
     header: { text: { withMobile: "Thanks" } },
     top: { text: { withMobile: "Position:" } },
     bottom: { text: { withMobile: "Please wait..." } },
+    state: { open: true },
+    kioskId: 456,
   };
   describe("when `position` is defined", () => {
     it("displays the current position", () => {
@@ -73,6 +77,33 @@ describe("InQueue", () => {
       data.position = null;
       const { getByText } = render(InQueue, data);
       expect(getByText(/thank you/i)).toBeInTheDocument();
+    });
+
+    it("resets the app state when clicking 'Back to check-in'", async () => {
+      data.position = null;
+      getData.mockReturnValue("getDataMockResponse");
+
+      render(InQueue, data);
+
+      await fireEvent.click(screen.getByRole("button"));
+      expect(getData).toBeCalled();
+      expect(stateResolver).toBeCalledWith("getDataMockResponse");
+    });
+
+    it("resets the app state after five minutes", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+      data.position = null;
+      getData.mockReturnValue("getDataMockResponse");
+
+      const fiveMinutesAgo = new Date() - 300000;
+
+      render(InQueue, {
+        readyTimestamp: fiveMinutesAgo,
+      });
+
+      await window.dispatchEvent(new Event("focus"));
+      expect(getData).toBeCalled();
+      expect(stateResolver).toBeCalledWith("getDataMockResponse");
     });
   });
 });

--- a/src/lib/models/kiosk.js
+++ b/src/lib/models/kiosk.js
@@ -1,11 +1,11 @@
 import { getData, getSettings } from "../services/kiosk";
-import isOpenResolver from "../resolvers/isOpen";
+import stateResolver from "../resolvers/state";
 import productsResolver from "../resolvers/products";
 import settingsForPostDataResolver from "../resolvers/settingsForPostData";
 import textResolver from "../resolvers/text";
 
 export default async function ({ fetch, page }) {
-  const kioskId = page.params.kioskId;
+  const { kioskId } = page.params;
 
   const [kioskData, kioskSettings] = await Promise.all([
     getData(fetch, kioskId),
@@ -13,12 +13,10 @@ export default async function ({ fetch, page }) {
   ]);
 
   const props = {
+    kioskId,
     products: productsResolver(kioskSettings),
     settingsForPostData: settingsForPostDataResolver(kioskSettings),
-    state: {
-      open: isOpenResolver(kioskData),
-      closed: !isOpenResolver(kioskData),
-    },
+    state: stateResolver(kioskData),
     text: textResolver(kioskSettings),
   };
 

--- a/src/lib/models/kiosk.test.js
+++ b/src/lib/models/kiosk.test.js
@@ -1,35 +1,40 @@
 import kiosk from "./kiosk";
 import { getData, getSettings } from "../services/kiosk";
-import isOpenResolver from "../resolvers/isOpen";
 import productsResolver from "../resolvers/products";
 import settingsForPostDataResolver from "../resolvers/settingsForPostData";
+import stateResolver from "../resolvers/state";
 import textResolver from "../resolvers/text";
 
 jest.mock("../services/kiosk");
-jest.mock("../resolvers/isOpen");
 jest.mock("../resolvers/products");
 jest.mock("../resolvers/settingsForPostData");
+jest.mock("../resolvers/state");
 jest.mock("../resolvers/text");
 
 describe("kiosk model", () => {
-  const data = { fetch: "fetchMock", page: { params: { kioskId: 123 } } };
+  const data = {
+    fetch: "fetchMock",
+    page: {
+      params: {
+        kioskId: 123,
+      },
+    },
+  };
 
   it("returns the correct data", async () => {
-    isOpenResolver.mockReturnValue(true);
     productsResolver.mockReturnValue("productsResolverMockResponse");
     settingsForPostDataResolver.mockReturnValue(
       "settingsForPostDataResolverMockResponse"
     );
+    stateResolver.mockReturnValue("stateResolverMockResponse");
     textResolver.mockReturnValue("textResolverMockResponse");
 
     const expected = {
       props: {
+        kioskId: 123,
         products: "productsResolverMockResponse",
         settingsForPostData: "settingsForPostDataResolverMockResponse",
-        state: {
-          open: true,
-          closed: false,
-        },
+        state: "stateResolverMockResponse",
         text: "textResolverMockResponse",
       },
     };
@@ -47,11 +52,11 @@ describe("kiosk model", () => {
     getSettings.mockReturnValue("getSettingsMockResponse");
 
     await kiosk(data);
-    expect(isOpenResolver).toBeCalledWith("getDataMockResponse");
     expect(productsResolver).toBeCalledWith("getSettingsMockResponse");
     expect(settingsForPostDataResolver).toBeCalledWith(
       "getSettingsMockResponse"
     );
+    expect(stateResolver).toBeCalledWith("getDataMockResponse");
     expect(textResolver).toBeCalledWith("getSettingsMockResponse");
   });
 });

--- a/src/lib/resolvers/state.js
+++ b/src/lib/resolvers/state.js
@@ -1,0 +1,8 @@
+import isOpenResolver from "./isOpen";
+
+export default function (kioskData) {
+  return {
+    open: isOpenResolver(kioskData),
+    closed: !isOpenResolver(kioskData),
+  };
+}

--- a/src/lib/resolvers/state.test.js
+++ b/src/lib/resolvers/state.test.js
@@ -1,0 +1,28 @@
+import stateResolver from "./state";
+import isOpenResolver from "./isOpen";
+
+jest.mock("./isOpen");
+
+describe("stateResolver", () => {
+  it("returns the correct data", () => {
+    isOpenResolver.mockReturnValue(true);
+    expect(stateResolver()).toEqual({
+      open: true,
+      closed: false,
+    });
+
+    isOpenResolver.mockReturnValue(false);
+    expect(stateResolver()).toEqual({
+      open: false,
+      closed: true,
+    });
+  });
+
+  it("calls the expected resolvers", () => {
+    stateResolver("kisokDataMock");
+    expect(isOpenResolver.mock.calls).toEqual([
+      ["kisokDataMock"],
+      ["kisokDataMock"],
+    ]);
+  });
+});

--- a/src/routes/[kioskId].svelte
+++ b/src/routes/[kioskId].svelte
@@ -11,10 +11,11 @@
   import { cookies } from "$lib/utils";
   import { AddToQueueForm, Closed, Header, InQueue } from "$components";
 
-  export let state;
+  export let kioskId;
   export let products;
-  export let text;
+  export let state;
   export let settingsForPostData;
+  export let text;
 
   if (state.open) {
     const currentCustomer = cookies.getCurrentCustomer();
@@ -41,7 +42,7 @@
 {/if}
 
 {#if state.inQueue}
-  <InQueue {...state} {...text.confirmationScreen} />
+  <InQueue bind:state {...state} {...text.confirmationScreen} {kioskId} />
 {/if}
 
 <style lang="scss">


### PR DESCRIPTION
Resolves #18 - Resets the app state after an elapsed time from check-in

- Makes a new API call after 5 minutes on window focus, to reset the app state
- The API call is more reliable than simply setting the state open, in case the user focuses the window out of hours, and is then incorrectly shown the check-in view
- We also display a Button to take the user back to the check-in screen
- Update babel & jest configs to assist in mocking @sapper/app (we aren't doing this, as it's still problematic even with this fix)
- Adds a stateResolver